### PR TITLE
Added the FrameML Class and updated the template File

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc3-ui-maker",
-  "version": "2.4.0",
+  "version": "2.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wc3-ui-maker",
-      "version": "2.4.0",
+      "version": "2.5.3",
       "license": "CC0-1.0",
       "dependencies": {
         "@material/textfield": "^10.0.0",

--- a/src/ts/Templates/FrameMLText.ts
+++ b/src/ts/Templates/FrameMLText.ts
@@ -1,0 +1,216 @@
+/** @format */
+
+export enum Language {
+  Lua = 'lua',
+  Jass = 'jass',
+  Typescript = 'ts',
+}
+
+export interface IMLTextMulti {
+  lua: string[]
+  jass: string[]
+  ts: string[]
+}
+
+export interface IMLTextSingle {
+  lua: string
+  jass: string
+  ts: string
+  name?: string
+}
+
+export class FrameMLText {
+  name: string
+  var: IMLTextSingle
+  private output: IMLTextMulti
+
+  private constructor(vars: IMLTextSingle) {
+    this.var = vars
+    this.name = vars.name ?? vars.jass ?? vars.lua ?? vars.ts
+    this.output = { ts: [], lua: [], jass: [] }
+  }
+
+  /**
+   *
+   * @param language Choose the language you want to output
+   * @param linePrefix Prefix this string to the beginning of each line; applies to first line as well.  Default is ""
+   * @param lineSuffix Suffix this string to the end of each line. Default is "\n"
+   * @returns string with the entire specified command
+   */
+  text = (language: Language, linePrefix?: string, lineSuffix = '\n') => {
+    const typedIndent = linePrefix ? linePrefix : ''
+
+    return lineSuffix + typedIndent + this.output[language].join(lineSuffix ? lineSuffix + typedIndent : '\n' + typedIndent) + lineSuffix
+  }
+
+  /**
+   * returns the code as JASS stitching everything together using the prefix and postfix
+   * @param linePrefix Prefix this string to the beginning of each line; applies to first line & last line as well.  Default is ""
+   * @param lineSuffix Suffix this string to the end of each line and before the start of the code. Default is "\n"
+   * @returns JASS String
+   */
+  jass = (linePrefix?: string, lineSuffix?: string) => {
+    return this.text(Language.Jass, linePrefix, lineSuffix)
+  }
+
+  /**
+   * returns the code as Lua stitching everything together using the prefix and postfix
+   * @param linePrefix Prefix this string to the beginning of each line; applies to first line & last line as well.  Default is ""
+   * @param lineSuffix Suffix this string to the end of each line and before the start of the code. Default is "\n"
+   * @returns LUA String
+   */
+  lua = (linePrefix?: string, lineSuffix?: string) => {
+    return this.text(Language.Lua, linePrefix, lineSuffix)
+  }
+
+  /**
+   * returns the code as Typscript stitching everything together using the prefix and postfix
+   * @param linePrefix Prefix this string to the beginning of each line; applies to first line & last line as well.  Default is ""
+   * @param lineSuffix Suffix this string to the end of each line and before the start of the code. Default is "\n"
+   * @returns TYPESCRIPT String
+   */
+  ts = (linePrefix?: string, lineSuffix?: string) => {
+    return this.text(Language.Typescript, linePrefix, lineSuffix)
+  }
+
+  // All of the following commands can be chained together and generate code in all of the languages
+  setAbsPoint = (point: string, x: number | string, y: number | string) => {
+    this.output.jass.push(`call BlzFrameSetAbsPoint(${this.var.jass}, ${point}, ${x}, ${y})`)
+    this.output.lua.push(`BlzFrameSetAbsPoint(${this.var.lua}, ${point}, ${x}, ${y})`)
+    this.output.ts.push(`  .setAbsPoint(${point}, ${x}, ${y})`)
+    return this
+  }
+
+  setAllPoints = (relativeFrame: FrameMLText | string) => {
+    this.output.jass.push(`call BlzFrameSetAllPoints(${this.var.jass}, ${typeof relativeFrame === 'string' ? relativeFrame : relativeFrame.var.jass})`)
+    this.output.lua.push(`BlzFrameSetAllPoints(${this.var.jass}, ${typeof relativeFrame === 'string' ? relativeFrame : relativeFrame.var.lua})`)
+    this.output.ts.push(`.setAllPoints(${typeof relativeFrame === 'string' ? relativeFrame : relativeFrame.var.ts})`)
+    return this
+  }
+
+  setTexture = (texFile: string, flag: number | string, blend: boolean | string) => {
+    this.output.jass.push(`call BlzFrameSetTexture(${this.var.jass}, ${texFile}, ${flag}, ${blend})`)
+    this.output.lua.push(`BlzFrameSetTexture(${this.var.lua}, ${texFile}, ${flag}, ${blend})`)
+    this.output.ts.push(`  .setTexture(${texFile}, ${flag}, ${blend})`)
+    return this
+  }
+
+  setText = (text: string) => {
+    this.output.jass.push(`call BlzFrameSetText(${this.var.jass}, ${text})`)
+    this.output.lua.push(`BlzFrameSetText(${this.var.lua}, ${text})`)
+    this.output.ts.push(`.setText(${text})`)
+    return this
+  }
+
+  setValue = (value: number | string) => {
+    this.output.jass.push(`call BlzFrameSetValue(${this.var.jass}, ${value})`)
+    this.output.lua.push(`BlzFrameSetValue(${this.var.lua}, ${value})`)
+    this.output.ts.push(`  .setValue(${value})`)
+    return this
+  }
+
+  setScale = (value: number | string) => {
+    this.output.jass.push(`call BlzFrameSetScale(${this.var.jass}, ${value})`)
+    this.output.lua.push(`BlzFrameSetScale(${this.var.lua}, ${value})`)
+    this.output.ts.push(`  .setScale(${value})`)
+    return this
+  }
+
+  setEnabled = (value: boolean | string) => {
+    this.output.jass.push(`call BlzFrameSetEnable(${this.var.jass}, ${value})`)
+    this.output.lua.push(`BlzFrameSetEnable(${this.var.lua}, ${value})`)
+    this.output.ts.push(`  .setEnabled(${value})`)
+    return this
+  }
+
+  setVisible = (value: boolean | string) => {
+    this.output.jass.push(`call BlzFrameSetVisible(${this.var.jass}, ${value})`)
+    this.output.lua.push(`BlzFrameSetVisible(${this.var.lua}, ${value})`)
+    this.output.ts.push(`  .setVisible(${value})`)
+    return this
+  }
+
+  setTextAlignment = (vert: string, horz: string) => {
+    this.output.jass.push(`call BlzFrameSetTextAlignment(${this.var.jass}, ${vert}, ${horz})`)
+    this.output.lua.push(`BlzFrameSetTextAlignment(${this.var.lua}, ${vert}, ${horz})`)
+    this.output.ts.push(`BlzFrameSetTextAlignment(${this.var.ts}.handle, ${vert}, ${horz})`)
+    return this
+  }
+
+  setToolTip = (tooltipFrame: string | this) => {
+    this.output.jass.push(`call BlzFrameSetTooltip(${this.var.jass}, ${typeof tooltipFrame === 'string' ? tooltipFrame : tooltipFrame.var.jass})`)
+    this.output.lua.push(`BlzFrameSetTooltip(${this.var.lua}, ${typeof tooltipFrame === 'string' ? tooltipFrame : tooltipFrame.var.lua})`)
+    this.output.ts.push(`  .setTooltip(${typeof tooltipFrame === 'string' ? tooltipFrame : tooltipFrame.var.lua})`)
+    return this
+  }
+
+  clear = () => {
+    this.output = { jass: [], lua: [], ts: [] }
+    return this
+  }
+
+  // Static Creations
+  static fromOrigin = (originFrame: string, createContext = 0) => {
+    const frameText = new FrameMLText({
+      jass: `BlzGetOriginFrame(${originFrame}, ${createContext})`,
+      lua: `BlzGetOriginFrame(${originFrame}, ${createContext})`,
+      ts: `Frame.fromOrigin(${originFrame}, ${createContext})`,
+      name: originFrame,
+    })
+    return frameText
+  }
+
+  static fromName = (frameName: string, createContext = 0) => {
+    const frameText = new FrameMLText({
+      jass: `BlzGetFrameByName(${frameName}, ${createContext})`,
+      lua: `BlzGetFrameByName(${frameName}, ${createContext})`,
+      ts: `Frame.fromName(${frameName}, ${createContext})`,
+      name: frameName,
+    })
+    return frameText
+  }
+
+  static newFrameByType = (varName: string, name: string, owner: FrameMLText | string, priority: number, createContext: number, type: string, inherits: string) => {
+    const frameText = new FrameMLText({
+      jass: `${varName}`,
+      lua: `${varName}`,
+      ts: `this.${varName}`,
+      name: name,
+    })
+    frameText.output.jass.push(
+      `set ${frameText.var.jass} = BlzCreateFrameByType("${type}", "${frameText.name}", ${
+        typeof owner === 'string' ? owner : owner.var.jass
+      }, "${inherits}", ${createContext})`
+    )
+    frameText.output.lua.push(
+      `${frameText.var.lua} = BlzCreateFrameByType("${type}", "${frameText.name}", ${typeof owner === 'string' ? owner : owner.var.lua}, "${inherits}", ${createContext})`
+    )
+    frameText.output.ts.push(
+      `${frameText.var.ts} = new Frame("${frameText.name}", ${typeof owner === 'string' ? owner : owner.var.ts}, ${priority}, ${createContext}, '${type}', "${inherits}")`
+    )
+    return frameText
+  }
+
+  static newFrame = (varName: string, name: string, owner: FrameMLText | string, priority: number, createContext: number) => {
+    const frameText = new FrameMLText({
+      jass: `${varName}`,
+      lua: `${varName}`,
+      ts: `this.${varName}`,
+      name: name,
+    })
+    frameText.output.jass.push(`set ${frameText.var.jass} = BlzCreateFrame("${frameText.name}", ${typeof owner === 'string' ? owner : owner.var.jass}, ${createContext})`)
+    frameText.output.lua.push(`${frameText.var.lua} = BlzCreateFrame("${frameText.name}", ${typeof owner === 'string' ? owner : owner.var.lua}, ${createContext})`)
+    frameText.output.ts.push(`${frameText.var.ts} = new Frame("${frameText.name}", ${typeof owner === 'string' ? owner : owner.var.ts}, ${priority}, ${createContext})`)
+    return frameText
+  }
+
+  static newEmpty = (varName: string, name = '') => {
+    const frameText = new FrameMLText({
+      jass: `${varName}`,
+      lua: `${varName}`,
+      ts: `this.${varName}`,
+      name: name,
+    })
+    return frameText
+  }
+}

--- a/src/ts/Templates/Templates.ts
+++ b/src/ts/Templates/Templates.ts
@@ -113,7 +113,7 @@ const HorizontalBarMLT = FrameMLText.newFrameByType('FRvar', 'name', 'OWNERvar',
   .setValue(100)
 
 // Horizontal Bar + Background
-const HorizontalBarWiBackground1MLT = FrameMLText.newFrameByType('FRvarBack', 'FRvarBack', OriginWorld, 0, 0, 'BACKDROP', '')
+const HorizontalBarWiBackground1MLT = FrameMLText.newFrameByType('BackFRvar', 'BackFRvar', OriginWorld, 0, 0, 'BACKDROP', '')
   .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
   .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
   .setTexture('BACKvar', 0, true)
@@ -129,7 +129,7 @@ const HorizontalBarWiText1MLT = FrameMLText.newFrameByType('FRvar', '', OriginWo
   .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
   .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
   .setValue(100)
-const HorizontalBarWiText2MLT = FrameMLText.newFrameByType('FRvarText', 'name', OriginGameUI, 0, 0, 'TEXT', '')
+const HorizontalBarWiText2MLT = FrameMLText.newFrameByType('TextFRvar', 'name', OriginGameUI, 0, 0, 'TEXT', '')
   .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
   .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
   .setText('TEXTvar')
@@ -138,7 +138,7 @@ const HorizontalBarWiText2MLT = FrameMLText.newFrameByType('FRvarText', 'name', 
   .setTextAlignment('ALIGN_VER', 'ALIGN_HOR')
 
 // Horizontal Bar + Background + Text
-const HorizontalBarWiBackground_Text1MLT = FrameMLText.newFrameByType('FRvarBack', 'FRvarBack', OriginWorld, 0, 0, 'BACKDROP', '')
+const HorizontalBarWiBackground_Text1MLT = FrameMLText.newFrameByType('BackFRvar', 'BackFRvar', OriginWorld, 0, 0, 'BACKDROP', '')
   .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
   .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
   .setTexture('BACKvar', 0, true)
@@ -147,7 +147,7 @@ const HorizontalBarWiBackground_Text2MLT = FrameMLText.newFrameByType('FRvar', '
   .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
   .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
   .setValue(100)
-const HorizontalBarWiBackground_Text3MLT = FrameMLText.newFrameByType('FRvarText', 'name', OriginGameUI, 0, 0, 'TEXT', '')
+const HorizontalBarWiBackground_Text3MLT = FrameMLText.newFrameByType('TextFRvar', 'name', OriginGameUI, 0, 0, 'TEXT', '')
   .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
   .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
   .setText('TEXTvar')
@@ -202,9 +202,9 @@ export class JASS implements I_Templates {
   // static declaresArrayWiTooltip = "framehandle array FRvar \nframehandle array TooltipFRvar \n"
   static declaresBUTTON = 'framehandle FRvar = null \n framehandle BackdropFRvar = null \n'
   // static declaresBUTTONArray = "framehandle array FRvar \n framehandle array BackdropFRvar \n"
-  static declaresHorBarBack = 'framehandle FRvar = null \nframehandle FRvarBack = null \n'
-  static declaresHorBarText = 'framehandle FRvar = null \nframehandle FRvarText = null \n'
-  static declaresHorBarBack_Text = 'framehandle FRvar = null \nframehandle FRvarBack = null \nframehandle FRvarText = null \n'
+  static declaresHorBarBack = 'framehandle FRvar = null \nframehandle BackFRvar = null \n'
+  static declaresHorBarText = 'framehandle FRvar = null \nframehandle TextFRvar = null \n'
+  static declaresHorBarBack_Text = 'framehandle FRvar = null \nframehandle BackFRvar = null \nframehandle TextFRvar = null \n'
 
   static declaresFUNCTIONALITY = 'trigger TriggerFRvar = null \n'
   // static declaresFUNCTIONALITYArray = "trigger array TriggerFRvar \n"
@@ -275,9 +275,9 @@ export class LUA implements I_Templates {
   // static declaresArrayWiTooltip = "FRvar = {} \n"
   static declaresBUTTON = 'FRvar = nil \nBackdropFRvar = nil \n'
   // static declaresBUTTONArray = "FRvar = {} \nBackdropFRvar = {} \n"
-  static declaresHorBarBack = 'FRvar = nil \nFRvarBack = nil \n'
-  static declaresHorBarText = 'FRvar = nil \nFRvarText = nil \n'
-  static declaresHorBarBack_Text = 'FRvar = nil \nFRvarBack = nil \nFRvarText = nil \n'
+  static declaresHorBarBack = 'FRvar = nil \nBackFRvar = nil \n'
+  static declaresHorBarText = 'FRvar = nil \nTextFRvar = nil \n'
+  static declaresHorBarBack_Text = 'FRvar = nil \nBackFRvar = nil \nTextFRvar = nil \n'
 
   static declaresFUNCTIONALITY = 'TriggerFRvar = nil \n'
   // static declaresFUNCTIONALITYArray = "TriggerFRvar = {} \n"
@@ -342,9 +342,9 @@ export class Typescript implements I_Templates {
   // static declaresArray = "   FRvar: Frame[] = []\n"
   static declaresBUTTON = '   FRvar: Frame\n   BackdropFRvar: Frame \n'
   // static declaresBUTTONArray = "   FRvar: Frame[] = []\n   BackdropFRvar: Frame[] = [] \n"
-  static declaresHorBarBack = 'FRvar: Frame \nFRvarBack: Frame \n'
-  static declaresHorBarText = 'FRvar: Frame \nFRvarText: Frame \n'
-  static declaresHorBarBack_Text = 'FRvar: Frame \nFRvarBack: Frame \nFRvarText: Frame \n'
+  static declaresHorBarBack = 'FRvar: Frame \nBackFRvar: Frame \n'
+  static declaresHorBarText = 'FRvar: Frame \nTextFRvar: Frame \n'
+  static declaresHorBarBack_Text = 'FRvar: Frame \nBackFRvar: Frame \nTextFRvar: Frame \n'
 
   static endglobals = '\n'
 

--- a/src/ts/Templates/Templates.ts
+++ b/src/ts/Templates/Templates.ts
@@ -1,243 +1,384 @@
-/* eslint-disable @typescript-eslint/no-namespace */
-//FRvar to skip array renaming, FRvrr to include array renaming
-//mainly used for stuff like FRvrrFunc, basically name being followed by a suffix
+/**
+ * /* eslint-disable @typescript-eslint/no-namespace
+ *
+ * @format
+ */
+
+import { FrameMLText } from './FrameMLText'
+
+// FRvar to skip array renaming, FRvrr to include array renaming
+// mainly used for stuff like FRvrrFunc, basically name being followed by a suffix
+
+///////////////////////////
+// Specify Global Frames //
+///////////////////////////
+
+// Origin Frames
+const OriginWorld = FrameMLText.fromOrigin('ORIGIN_FRAME_WORLD_FRAME')
+const OriginGameUI = FrameMLText.fromOrigin('ORIGIN_FRAME_GAME_UI')
+const OriginHeroBar = FrameMLText.fromOrigin('ORIGIN_FRAME_HERO_BAR')
+const OriginMinimap = FrameMLText.fromOrigin('ORIGIN_FRAME_MINIMAP')
+const OriginPortrait = FrameMLText.fromOrigin('ORIGIN_FRAME_PORTRAIT')
+const OriginChatMsg = FrameMLText.fromOrigin('ORIGIN_FRAME_CHAT_MSG')
+
+// Frames from Names
+const FrameConsoleUIBackdrop = FrameMLText.fromName('ConsoleUIBackdrop')
+const FrameResourceBarFrame = FrameMLText.fromName('ResourceBarFrame')
+const FrameUpperButtonBarFrame = FrameMLText.fromName('UpperButtonBarFrame')
+
+///////////////////////////
+// Specify Custom Frames //
+///////////////////////////
+
+// Backdrop
+const BackdropMLT = FrameMLText.newFrameByType('FRvar', 'BACKDROP', 'OWNERvar', 1, 1, 'BACKDROP', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setTexture('PATHvar', 0, true)
+
+// Button + Backdrop
+const Button1MLT = FrameMLText.newFrame('FRvar', 'ScriptDialogButton', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+const Button2MLT = FrameMLText.newFrameByType('BackdropFRvar', 'BackdropFRvar', Button1MLT, 0, 0, 'BACKDROP', '').setAllPoints(Button1MLT).setTexture('PATHvar', 0, true)
+
+// Dialog Button
+const ScriptDialogButtonMLT = FrameMLText.newFrame('FRvar', 'ScriptDialogButton', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setText('TEXTvar')
+  .setScale('FRscale')
+
+// Browser Button
+const BrowserButtonMLT = FrameMLText.newFrame('FRvar', 'BrowserButton', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setText('TEXTvar')
+  .setScale('FRscale')
+
+// Check List Box
+const CheckListBoxMLT = FrameMLText.newFrame('FRvar', 'CheckListBox', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Esc Menu Backdrop
+const EscMenuBackdropMLT = FrameMLText.newFrame('FRvar', 'EscMenuBackdrop', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Options Popup Menu Backdrop Template
+const OptionsPopupMenuBackdropTemplateMLT = FrameMLText.newFrame('FRvar', 'OptionsPopupMenuBackdropTemplate', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Quest Button Base Backdrop Template
+const QuestButtonBaseTemplateMLT = FrameMLText.newFrame('FRvar', 'QuestButtonBaseTemplate', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Quest Button Disabled Backdrop Template
+const QuestButtonDisabledBackdropTemplateMLT = FrameMLText.newFrame('FRvar', 'QuestButtonDisabledBackdropTemplate', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Quest Button Pushed Backdrop Template
+const QuestButtonPushedBackdropTemplateMLT = FrameMLText.newFrame('FRvar', 'QuestButtonPushedBackdropTemplate', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Quest Check Box
+const QuestCheckBoxMLT = FrameMLText.newFrame('FRvar', 'QuestCheckBox', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Invisible Button
+const InvisButtonMLT = FrameMLText.newFrameByType('FRvar', 'name', 'OWNERvar', 0, 0, 'GLUEBUTTON', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+
+// Text Frame
+const TextFrameMLT = FrameMLText.newFrameByType('FRvar', 'name', 'OWNERvar', 0, 0, 'TEXT', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setText('TEXTvar')
+  .setEnabled(false)
+  .setScale('FRscale')
+  .setTextAlignment('ALIGN_VER', 'ALIGN_HOR')
+
+// Horizontal Bar
+const HorizontalBarMLT = FrameMLText.newFrameByType('FRvar', 'name', 'OWNERvar', 0, 0, 'SIMPLESTATUSBAR', '')
+  .setTexture('PATHvar', 0, true)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setValue(100)
+
+// Horizontal Bar + Background
+const HorizontalBarWiBackground1MLT = FrameMLText.newFrameByType('FRvarBack', 'FRvarBack', OriginWorld, 0, 0, 'BACKDROP', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setTexture('BACKvar', 0, true)
+const HorizontalBarWiBackground2MLT = FrameMLText.newFrameByType('FRvar', '', HorizontalBarWiBackground1MLT, 0, 0, 'SIMPLESTATUSBAR', '')
+  .setTexture('PATHvar', 0, true)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setValue(50)
+
+// Horizontal Bar + Text
+const HorizontalBarWiText1MLT = FrameMLText.newFrameByType('FRvar', '', OriginWorld, 0, 0, 'SIMPLESTATUSBAR', '')
+  .setTexture('PATHvar', 0, true)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setValue(100)
+const HorizontalBarWiText2MLT = FrameMLText.newFrameByType('FRvarText', 'name', OriginGameUI, 0, 0, 'TEXT', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setText('TEXTvar')
+  .setEnabled(false)
+  .setScale('FRscale')
+  .setTextAlignment('ALIGN_VER', 'ALIGN_HOR')
+
+// Horizontal Bar + Background + Text
+const HorizontalBarWiBackground_Text1MLT = FrameMLText.newFrameByType('FRvarBack', 'FRvarBack', OriginWorld, 0, 0, 'BACKDROP', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setTexture('BACKvar', 0, true)
+const HorizontalBarWiBackground_Text2MLT = FrameMLText.newFrameByType('FRvar', '', HorizontalBarWiBackground_Text1MLT, 0, 0, 'SIMPLESTATUSBAR', '')
+  .setTexture('PATHvar', 0, true)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setValue(100)
+const HorizontalBarWiBackground_Text3MLT = FrameMLText.newFrameByType('FRvarText', 'name', OriginGameUI, 0, 0, 'TEXT', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setText('TEXTvar')
+  .setEnabled(false)
+  .setScale('FRscale')
+  .setTextAlignment('ALIGN_VER', 'ALIGN_HOR')
+
+// Text Area
+const TextAreaMLT = FrameMLText.newFrameByType('FRvar', 'name', 'OWNERvar', 0, 0, 'TEXTAREA', '')
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setText('TEXTvar')
+
+// Edit Box
+const EditBoxMLT = FrameMLText.newFrame('FRvar', 'EscMenuEditBoxTemplate', 'OWNERvar', 0, 0)
+  .setAbsPoint('FRAMEPOINT_TOPLEFT', 'TOPLEFTXvar', 'TOPLEFTYvar')
+  .setAbsPoint('FRAMEPOINT_BOTTOMRIGHT', 'BOTRIGHTXvar', 'BOTRIGHTYvar')
+  .setText('TEXTvar')
+
+// Tooltip Owner Button
+const TooltipOwnerButtonMLT = FrameMLText.newEmpty('OWNERvar').setToolTip('FRvar')
+
+// Tooltip Owner Other
+const TooltipOwnerOtherMLT = FrameMLText.newFrameByType('TooltipFRvar', '', 'OWNERvar', 0, 0, 'FRAME', '').setAllPoints('OWNERvar').setToolTip('FRvar')
 
 export abstract class I_Templates {
-    static ScriptDialogButton: string
-    static BrowserButton: string
-    static CheckListBox: string
-    static EscMenuBackdrop: string
-    static OptionsPopupMenuBackdropTemplate: string
-    static QuestButtonBaseTemplate: string
-    static QuestButtonDisabledBackdropTemplate: string
-    static QuestButtonPushedBackdropTemplate: string
-    static QuestCheckBox: string
-    static InvisButton: string
-    static TextFrame: string
-    static HorizontalBar: string
-    static HorizontalBarWiBackground: string
-    static HorizontalBarWiText: string
-    static HorizontalBarWiBackground_Text: string
-    static TextArea: string
-    static EditBox: string
+  static ScriptDialogButton: string
+  static BrowserButton: string
+  static CheckListBox: string
+  static EscMenuBackdrop: string
+  static OptionsPopupMenuBackdropTemplate: string
+  static QuestButtonBaseTemplate: string
+  static QuestButtonDisabledBackdropTemplate: string
+  static QuestButtonPushedBackdropTemplate: string
+  static QuestCheckBox: string
+  static InvisButton: string
+  static TextFrame: string
+  static HorizontalBar: string
+  static HorizontalBarWiBackground: string
+  static HorizontalBarWiText: string
+  static HorizontalBarWiBackground_Text: string
+  static TextArea: string
+  static EditBox: string
 }
 
 export class JASS implements I_Templates {
-    static globals = "globals \n"
+  static globals = 'globals \n'
 
-    static declares = "framehandle FRvar = null \n"
-    // static declaresArray = "framehandle array FRvar\n"
-    static declaresWiTooltip = "framehandle FRvar = null \nframehandle TooltipFRvar = null \n"
-    // static declaresArrayWiTooltip = "framehandle array FRvar \nframehandle array TooltipFRvar \n"
-    static declaresBUTTON = "framehandle FRvar = null \n framehandle BackdropFRvar = null \n"
-    // static declaresBUTTONArray = "framehandle array FRvar \n framehandle array BackdropFRvar \n"
-    static declaresHorBarBack = "framehandle FRvar = null \nframehandle BackFRvar = null \n"
-    static declaresHorBarText = "framehandle FRvar = null \nframehandle TextFRvar = null \n"
-    static declaresHorBarBack_Text = "framehandle FRvar = null \nframehandle BackFRvar = null \nframehandle TextFRvar = null \n"
+  static declares = 'framehandle FRvar = null \n'
+  // static declaresArray = "framehandle array FRvar\n"
+  static declaresWiTooltip = 'framehandle FRvar = null \nframehandle TooltipFRvar = null \n'
+  // static declaresArrayWiTooltip = "framehandle array FRvar \nframehandle array TooltipFRvar \n"
+  static declaresBUTTON = 'framehandle FRvar = null \n framehandle BackdropFRvar = null \n'
+  // static declaresBUTTONArray = "framehandle array FRvar \n framehandle array BackdropFRvar \n"
+  static declaresHorBarBack = 'framehandle FRvar = null \nframehandle FRvarBack = null \n'
+  static declaresHorBarText = 'framehandle FRvar = null \nframehandle FRvarText = null \n'
+  static declaresHorBarBack_Text = 'framehandle FRvar = null \nframehandle FRvarBack = null \nframehandle FRvarText = null \n'
 
-    static declaresFUNCTIONALITY = "trigger TriggerFRvar = null \n"
-    // static declaresFUNCTIONALITYArray = "trigger array TriggerFRvar \n"
+  static declaresFUNCTIONALITY = 'trigger TriggerFRvar = null \n'
+  // static declaresFUNCTIONALITYArray = "trigger array TriggerFRvar \n"
 
-    static declaresFUNCTIONALITYcheckbox = "trigger TriggerChFRvar = null \n"
-    // static declaresFUNCTIONALITYArraycheckbox = "trigger array TriggerChFRvar \n"
+  static declaresFUNCTIONALITYcheckbox = 'trigger TriggerChFRvar = null \n'
+  // static declaresFUNCTIONALITYArraycheckbox = "trigger array TriggerChFRvar \n"
 
-    static endglobals = "endglobals \n \n"
+  static endglobals = 'endglobals \n \n'
 
-    static library = "library FRlib initializer init \n"
-    static libraryInit = "private function init takes nothing returns nothing \n"
+  static library = 'library FRlib initializer init \n'
+  static libraryInit = 'private function init takes nothing returns nothing \n'
 
-    static TriggerButtonDisableStart = 'function FRvrrFunc takes nothing returns nothing \ncall BlzFrameSetEnable(FRvar, false) \ncall BlzFrameSetEnable(FRvar, true) \n'
-    static TriggerVariableInit = 'set TRIGvar = GetConvertedPlayerId(GetTriggerPlayer()) \n'
-    static TriggerButtonDisableEnd = 'endfunction \n \n'
+  static TriggerButtonDisableStart = 'function FRvrrFunc takes nothing returns nothing \ncall BlzFrameSetEnable(FRvar, false) \ncall BlzFrameSetEnable(FRvar, true) \n'
+  static TriggerVariableInit = 'set TRIGvar = GetConvertedPlayerId(GetTriggerPlayer()) \n'
+  static TriggerButtonDisableEnd = 'endfunction \n \n'
 
-    static TriggerCheckboxStart = 'function FRvrrChFunc takes nothing returns nothing \n'
-    static TriggerCheckboxTrig = 'if BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_CHECKED then\nset TRIGvar = 2\nelse \nset TRIGvar = 1\nendif\n'
-    static TriggerCheckboxEnd = 'endfunction \n \n'
+  static TriggerCheckboxStart = 'function FRvrrChFunc takes nothing returns nothing \n'
+  static TriggerCheckboxTrig = 'if BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_CHECKED then\nset TRIGvar = 2\nelse \nset TRIGvar = 1\nendif\n'
+  static TriggerCheckboxEnd = 'endfunction \n \n'
 
-    static backdrop = '\nset FRvar = BlzCreateFrameByType("BACKDROP", "FRvar", OWNERvar, "", 1) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n call BlzFrameSetTexture(FRvar, PATHvar, 0, true) \n'
+  static backdrop = BackdropMLT.jass()
+  static button = Button1MLT.jass() + Button2MLT.jass()
+  static ScriptDialogButton = ScriptDialogButtonMLT.jass()
+  static BrowserButton = BrowserButtonMLT.jass()
+  static CheckListBox = CheckListBoxMLT.jass()
+  static EscMenuBackdrop = EscMenuBackdropMLT.jass()
+  static OptionsPopupMenuBackdropTemplate = OptionsPopupMenuBackdropTemplateMLT.jass()
+  static QuestButtonBaseTemplate = QuestButtonBaseTemplateMLT.jass()
+  static QuestButtonDisabledBackdropTemplate = QuestButtonDisabledBackdropTemplateMLT.jass()
+  static QuestButtonPushedBackdropTemplate = QuestButtonPushedBackdropTemplateMLT.jass()
+  static QuestCheckBox = QuestCheckBoxMLT.jass()
+  static InvisButton = InvisButtonMLT.jass()
+  static TextFrame = TextFrameMLT.jass()
+  static HorizontalBar = HorizontalBarMLT.jass()
+  static HorizontalBarWiBackground = HorizontalBarWiBackground1MLT.jass() + HorizontalBarWiBackground2MLT.jass()
+  static HorizontalBarWiText = HorizontalBarWiText1MLT.jass() + HorizontalBarWiText2MLT.jass()
+  static HorizontalBarWiBackground_Text =
+    HorizontalBarWiBackground_Text1MLT.jass() + HorizontalBarWiBackground_Text2MLT.jass() + HorizontalBarWiBackground_Text3MLT.jass()
+  static TextArea = TextAreaMLT.jass()
+  static EditBox = EditBoxMLT.jass()
 
-    static button = '\nset FRvar = BlzCreateFrame("ScriptDialogButton", OWNERvar, 0, 0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n set BackdropFRvar = BlzCreateFrameByType("BACKDROP", "BackdropFRvar", FRvar, "", 1) \n call BlzFrameSetAllPoints(BackdropFRvar, FRvar) \n call BlzFrameSetTexture(BackdropFRvar, PATHvar, 0, true) \n'
+  static TooltipOwnerButton = TooltipOwnerButtonMLT.jass()
+  static TooltipOwnerOther = TooltipOwnerOtherMLT.jass()
 
-    static ScriptDialogButton = '\nset FRvar = BlzCreateFrame("ScriptDialogButton", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n call BlzFrameSetText(FRvar, TEXTvar) \ncall BlzFrameSetScale(FRvar, FRscale) \n '
-    static BrowserButton = '\nset FRvar = BlzCreateFrame("BrowserButton", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n call BlzFrameSetText(FRvar, TEXTvar) \ncall BlzFrameSetScale(FRvar, FRscale) \n'
-    static CheckListBox = '\nset FRvar = BlzCreateFrame("CheckListBox", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static EscMenuBackdrop = '\nset FRvar = BlzCreateFrame("EscMenuBackdrop", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static OptionsPopupMenuBackdropTemplate = '\nset FRvar = BlzCreateFrame("OptionsPopupMenuBackdropTemplate", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonBaseTemplate = '\nset FRvar = BlzCreateFrame("QuestButtonBaseTemplate", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonDisabledBackdropTemplate = '\nset FRvar = BlzCreateFrame("QuestButtonDisabledBackdropTemplate", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonPushedBackdropTemplate = '\nset FRvar = BlzCreateFrame("QuestButtonPushedBackdropTemplate", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestCheckBox = '\nset FRvar = BlzCreateFrame("QuestCheckBox", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static InvisButton = '\nset FRvar = BlzCreateFrameByType("GLUEBUTTON", "name", OWNERvar, "",0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static TextFrame = `\nset FRvar = BlzCreateFrameByType("TEXT", "name", OWNERvar, "", 0) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \ncall BlzFrameSetText(FRvar, TEXTvar) \ncall BlzFrameSetEnable(FRvar, false) \ncall BlzFrameSetScale(FRvar, FRscale) \ncall BlzFrameSetTextAlignment(FRvar, ALIGN_VER, ALIGN_HOR) \n`
-    static HorizontalBar = '\nset FRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", OWNERvar, "", 0) \ncall BlzFrameSetTexture(FRvar, PATHvar, 0, true) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \ncall BlzFrameSetValue(FRvar, 100) \n'
-    static HorizontalBarWiBackground = '\nset BackFRvar = BlzCreateFrameByType("BACKDROP", "BackFRvar", BlzGetOriginFrame(ORIGIN_FRAME_WORLD_FRAME, 0), "", 1) \n call BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n call BlzFrameSetTexture(BackFRvar, BACKvar, 0, true) \nset FRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", BackFRvar, "", 0) \ncall BlzFrameSetTexture(FRvar, PATHvar, 0, true) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \ncall BlzFrameSetValue(FRvar, 50) \n'
-    static HorizontalBarWiText = '\nset FRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", BlzGetOriginFrame(ORIGIN_FRAME_WORLD_FRAME, 0), "", 0) \ncall BlzFrameSetTexture(FRvar, PATHvar, 0, true) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \ncall BlzFrameSetValue(FRvar, 100) \nset TextFRvar = BlzCreateFrameByType("TEXT", "name", BlzGetOriginFrame( ORIGIN_FRAME_GAME_UI, 0), "", 0) \ncall BlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \ncall BlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \ncall BlzFrameSetText(TextFRvar, TEXTvar) \ncall BlzFrameSetEnable(TextFRvar, false) \ncall BlzFrameSetScale(TextFRvar, FRscale) \ncall BlzFrameSetTextAlignment(TextFRvar, ALIGN_VER, ALIGN_HOR) \n'
-    static HorizontalBarWiBackground_Text = '\nset BackFRvar = BlzCreateFrameByType("BACKDROP", "BackFRvar", BlzGetOriginFrame(ORIGIN_FRAME_WORLD_FRAME, 0), "", 1) \n call BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n call BlzFrameSetTexture(BackFRvar, BACKvar, 0, true) \nset FRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", BackFRvar, "", 0) \ncall BlzFrameSetTexture(FRvar, PATHvar, 0, true) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \ncall BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \ncall BlzFrameSetValue(FRvar, 100) \nset TextFRvar = BlzCreateFrameByType("TEXT", "name", BlzGetOriginFrame( ORIGIN_FRAME_GAME_UI, 0), "", 0) \ncall BlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \ncall BlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \ncall BlzFrameSetText(TextFRvar, TEXTvar) \ncall BlzFrameSetEnable(TextFRvar, false) \ncall BlzFrameSetScale(TextFRvar, FRscale) \ncall BlzFrameSetTextAlignment(TextFRvar, ALIGN_VER, ALIGN_HOR) \n'
-    static TextArea = `\nset FRvar = BlzCreateFrameByType("TEXTAREA", "name", OWNERvar, "EscMenuTextAreaTemplate", 0)\n  call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n    call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  call BlzFrameSetText(FRvar, TEXTvar)\n`
-    static EditBox = '\nset FRvar = BlzCreateFrame("EscMenuEditBoxTemplate", OWNERvar,0,0) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n call BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n call BlzFrameSetText(FRvar, TEXTvar) \n'
+  static TriggerVariableFinalButton =
+    'set TriggerFRvar = CreateTrigger() \n call BlzTriggerRegisterFrameEvent(TriggerFRvar, FRvar, FRAMEEVENT_CONTROL_CLICK) \n call TriggerAddAction(TriggerFRvar, function FRvrrFunc) \n'
+  static TriggerVariableCheckbox =
+    'set TriggerChFRvar = CreateTrigger() \n call BlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_CHECKED) \ncall BlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_UNCHECKED) \n call TriggerAddAction(TriggerChFRvar, function FRvrrChFunc) \n'
 
+  static endlibrary = 'endfunction \nendlibrary\n'
 
-    static TooltipOwnerButton = `call BlzFrameSetTooltip(OWNERvar, FRvar) \n`
-    static TooltipOwnerOther = `set TooltipFRvar = BlzCreateFrameByType("FRAME", "", OWNERvar,"", 0) \ncall BlzFrameSetAllPoints(TooltipFRvar, OWNERvar) \ncall BlzFrameSetTooltip(TooltipFRvar, FRvar) \n`
-
-    static TriggerVariableFinalButton = 'set TriggerFRvar = CreateTrigger() \n call BlzTriggerRegisterFrameEvent(TriggerFRvar, FRvar, FRAMEEVENT_CONTROL_CLICK) \n call TriggerAddAction(TriggerFRvar, function FRvrrFunc) \n'
-    static TriggerVariableCheckbox = 'set TriggerChFRvar = CreateTrigger() \n call BlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_CHECKED) \ncall BlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_UNCHECKED) \n call TriggerAddAction(TriggerChFRvar, function FRvrrChFunc) \n'
-
-    static endlibrary = "endfunction \nendlibrary\n"
-
-
-    static HideGameUI = 'call BlzHideOriginFrames(true) \ncall BlzFrameSetSize(BlzGetFrameByName("ConsoleUIBackdrop",0), 0, 0.0001)\n'
-    static HideHeroBar = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_HERO_BAR,0), false)\n';
-    static HideMiniMap = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_MINIMAP,0), false)\n'
-    static HideResources = 'call BlzFrameSetVisible(BlzGetFrameByName("ResourceBarFrame",0), false)\n'
-    static HideButtonBar = 'call BlzFrameSetVisible(BlzGetFrameByName("UpperButtonBarFrame",0), false)\n'
-    static HidePortrait = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_PORTRAIT, 0), false)\n'
-    static HideChat = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_CHAT_MSG, 0), false)\n'
-    static LoadTOC = 'call BlzLoadTOCFile("name.toc")'
+  static HideGameUI = 'call BlzHideOriginFrames(true) \ncall BlzFrameSetSize(BlzGetFrameByName("ConsoleUIBackdrop",0), 0, 0.0001)\n'
+  static HideHeroBar = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_HERO_BAR,0), false)\n'
+  static HideMiniMap = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_MINIMAP,0), false)\n'
+  static HideResources = 'call BlzFrameSetVisible(BlzGetFrameByName("ResourceBarFrame",0), false)\n'
+  static HideButtonBar = 'call BlzFrameSetVisible(BlzGetFrameByName("UpperButtonBarFrame",0), false)\n'
+  static HidePortrait = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_PORTRAIT, 0), false)\n'
+  static HideChat = 'call BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_CHAT_MSG, 0), false)\n'
+  static LoadTOC = 'call BlzLoadTOCFile("name.toc")'
 }
-
- 
-
 
 export class LUA implements I_Templates {
-    static globals = ""
+  static globals = ''
 
-    static declares = "FRvar = nil \n"
-    static declaresWiTooltip = "FRvar = nil \n"
-    // static declaresArray = "FRvar = {} \n"
-    // static declaresArrayWiTooltip = "FRvar = {} \n"
-    static declaresBUTTON = "FRvar = nil \nBackdropFRvar = nil \n"
-    // static declaresBUTTONArray = "FRvar = {} \nBackdropFRvar = {} \n"
-    static declaresHorBarBack = "FRvar = nil \nBackFRvar = nil \n"
-    static declaresHorBarText = "FRvar = nil \nTextFRvar = nil \n"
-    static declaresHorBarBack_Text = "FRvar = nil \nBackFRvar = nil \nTextFRvar = nil \n"
+  static declares = 'FRvar = nil \n'
+  static declaresWiTooltip = 'FRvar = nil \n'
+  // static declaresArray = "FRvar = {} \n"
+  // static declaresArrayWiTooltip = "FRvar = {} \n"
+  static declaresBUTTON = 'FRvar = nil \nBackdropFRvar = nil \n'
+  // static declaresBUTTONArray = "FRvar = {} \nBackdropFRvar = {} \n"
+  static declaresHorBarBack = 'FRvar = nil \nFRvarBack = nil \n'
+  static declaresHorBarText = 'FRvar = nil \nFRvarText = nil \n'
+  static declaresHorBarBack_Text = 'FRvar = nil \nFRvarBack = nil \nFRvarText = nil \n'
 
-    static declaresFUNCTIONALITY = "TriggerFRvar = nil \n"
-    // static declaresFUNCTIONALITYArray = "TriggerFRvar = {} \n"
-    
-    static endglobals = ""
+  static declaresFUNCTIONALITY = 'TriggerFRvar = nil \n'
+  // static declaresFUNCTIONALITYArray = "TriggerFRvar = {} \n"
 
-    static library = "FRlib = {}\n"
-    static libraryInit = "FRlib.Initialize = function()\n"
-    static TriggerButtonDisableStart = 'FRlib.FRvrrFunc = function() \nBlzFrameSetEnable(FRvar, false) \nBlzFrameSetEnable(FRvar, true) \n'
-    static TriggerVariableInit = "globals.TRIGvar = GetConvertedPlayerId(GetTriggerPlayer()) \n"
-    static TriggerButtonDisableEnd = 'end \n \n'
-    
-    static backdrop = '\nFRvar = BlzCreateFrameByType("BACKDROP", "FRvar", OWNERvar, "", 1) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetTexture(FRvar, PATHvar, 0, true) \n'
+  static endglobals = ''
 
-    static button = '\nFRvar = BlzCreateFrame("ScriptDialogButton", OWNERvar, 0, 0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBackdropFRvar = BlzCreateFrameByType("BACKDROP", "BackdropFRvar", FRvar, "", 1) \nBlzFrameSetAllPoints(BackdropFRvar, FRvar) \nBlzFrameSetTexture(BackdropFRvar, PATHvar, 0, true) \n'
+  static library = 'FRlib = {}\n'
+  static libraryInit = 'FRlib.Initialize = function()\n'
+  static TriggerButtonDisableStart = 'FRlib.FRvrrFunc = function() \nBlzFrameSetEnable(FRvar, false) \nBlzFrameSetEnable(FRvar, true) \n'
+  static TriggerVariableInit = 'globals.TRIGvar = GetConvertedPlayerId(GetTriggerPlayer()) \n'
+  static TriggerButtonDisableEnd = 'end \n \n'
 
-    static ScriptDialogButton = '\nFRvar = BlzCreateFrame("ScriptDialogButton", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetText(FRvar, TEXTvar) \nBlzFrameSetScale(FRvar, FRscale) \n '
-    static BrowserButton = '\nFRvar = BlzCreateFrame("BrowserButton", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetText(FRvar, TEXTvar) \nBlzFrameSetScale(FRvar, FRscale) \n'
-    static CheckListBox = '\nFRvar = BlzCreateFrame("CheckListBox", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static EscMenuBackdrop = '\nFRvar = BlzCreateFrame("EscMenuBackdrop", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static OptionsPopupMenuBackdropTemplate = '\nFRvar = BlzCreateFrame("OptionsPopupMenuBackdropTemplate", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonBaseTemplate = '\nFRvar = BlzCreateFrame("QuestButtonBaseTemplate", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonDisabledBackdropTemplate = '\nFRvar = BlzCreateFrame("QuestButtonDisabledBackdropTemplate", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonPushedBackdropTemplate = '\nFRvar = BlzCreateFrame("QuestButtonPushedBackdropTemplate", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestCheckBox = '\nFRvar = BlzCreateFrame("QuestCheckBox", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static InvisButton = '\nFRvar = BlzCreateFrameByType("GLUEBUTTON", "name", OWNERvar, "",0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static TextFrame = `\nFRvar = BlzCreateFrameByType("TEXT", "name", OWNERvar, "", 0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetText(FRvar, TEXTvar) \nBlzFrameSetEnable(FRvar, false) \nBlzFrameSetScale(FRvar, FRscale) \nBlzFrameSetTextAlignment(FRvar, ALIGN_VER, ALIGN_HOR) \n`
-    static HorizontalBar = '\nFRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", OWNERvar, "", 0) \nBlzFrameSetTexture(FRvar, PATHvar, 0, true) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetValue(FRvar, 100) \n'
-    static HorizontalBarWiBackground = '\nBackFRvar = BlzCreateFrameByType("BACKDROP", "BackFRvar", BlzGetOriginFrame(ORIGIN_FRAME_WORLD_FRAME, 0), "", 1) \n BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n BlzFrameSetTexture(BackFRvar, BACKvar, 0, true) \nFRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", BackFRvar, "", 0) \nBlzFrameSetTexture(FRvar, PATHvar, 0, true) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetValue(FRvar, 50) \n'
-    static HorizontalBarWiText = '\nFRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", BlzGetOriginFrame(ORIGIN_FRAME_WORLD_FRAME, 0), "", 0) \nBlzFrameSetTexture(FRvar, PATHvar, 0, true) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetValue(FRvar, 100) \nTextFRvar = BlzCreateFrameByType("TEXT", "name", BlzGetOriginFrame( ORIGIN_FRAME_GAME_UI, 0), "", 0) \nBlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetText(TextFRvar, TEXTvar) \nBlzFrameSetEnable(TextFRvar, false) \nBlzFrameSetScale(TextFRvar, FRscale) \nBlzFrameSetTextAlignment(TextFRvar, ALIGN_VER, ALIGN_HOR) \n'
-    static HorizontalBarWiBackground_Text = '\nBackFRvar = BlzCreateFrameByType("BACKDROP", "BackFRvar", BlzGetOriginFrame(ORIGIN_FRAME_WORLD_FRAME, 0), "", 1) \n BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n BlzFrameSetAbsPoint(BackFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n BlzFrameSetTexture(BackFRvar, BACKvar, 0, true) \nFRvar = BlzCreateFrameByType("SIMPLESTATUSBAR", "", BackFRvar, "", 0) \nBlzFrameSetTexture(FRvar, PATHvar, 0, true) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetValue(FRvar, 100) \nTextFRvar = BlzCreateFrameByType("TEXT", "name", BlzGetOriginFrame( ORIGIN_FRAME_GAME_UI, 0), "", 0) \nBlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(TextFRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetText(TextFRvar, TEXTvar) \nBlzFrameSetEnable(TextFRvar, false) \nBlzFrameSetScale(TextFRvar, FRscale) \nBlzFrameSetTextAlignment(TextFRvar, ALIGN_VER, ALIGN_HOR) \n'
-    static TextArea = `FRvar = BlzCreateFrameByType("TEXTAREA", "name", OWNERvar, "EscMenuTextAreaTemplate", 0)\n   BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n    BlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n   BlzFrameSetText(FRvar, TEXTvar)\n`
-    static EditBox = '\nFRvar = BlzCreateFrame("EscMenuEditBoxTemplate", OWNERvar,0,0) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \nBlzFrameSetAbsPoint(FRvar, FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nBlzFrameSetText(FRvar, TEXTvar) \n'
+  static backdrop = BackdropMLT.lua()
 
+  static button = Button1MLT.lua() + Button2MLT.lua()
 
+  static ScriptDialogButton = ScriptDialogButtonMLT.lua()
+  static BrowserButton = BrowserButtonMLT.lua()
+  static CheckListBox = CheckListBoxMLT.lua()
+  static EscMenuBackdrop = EscMenuBackdropMLT.lua()
+  static OptionsPopupMenuBackdropTemplate = OptionsPopupMenuBackdropTemplateMLT.lua()
+  static QuestButtonBaseTemplate = QuestButtonBaseTemplateMLT.lua()
+  static QuestButtonDisabledBackdropTemplate = QuestButtonDisabledBackdropTemplateMLT.lua()
+  static QuestButtonPushedBackdropTemplate = QuestButtonPushedBackdropTemplateMLT.lua()
+  static QuestCheckBox = QuestCheckBoxMLT.lua()
+  static InvisButton = InvisButtonMLT.lua()
+  static TextFrame = TextFrameMLT.lua()
+  static HorizontalBar = HorizontalBarMLT.lua()
+  static HorizontalBarWiBackground = HorizontalBarWiBackground1MLT.lua() + HorizontalBarWiBackground2MLT.lua()
+  static HorizontalBarWiText = HorizontalBarWiText1MLT.lua() + HorizontalBarWiText2MLT.lua()
+  static HorizontalBarWiBackground_Text = HorizontalBarWiBackground_Text1MLT.lua() + HorizontalBarWiBackground_Text2MLT.lua() + HorizontalBarWiBackground_Text3MLT.lua()
+  static TextArea = TextAreaMLT.lua()
+  static EditBox = EditBoxMLT.lua()
 
-    static TooltipOwnerButton = `BlzFrameSetTooltip(OWNERvar, FRvar) \n`
-    static TooltipOwnerOther = `TooltipFRvar = BlzCreateFrameByType("FRAME", "", OWNERvar,"", 0) \nBlzFrameSetAllPoints(TooltipFRvar, OWNERvar) \nBlzFrameSetTooltip(TooltipFRvar, FRvar) \n`
+  static TooltipOwnerButton = TooltipOwnerButtonMLT.lua()
+  static TooltipOwnerOther = TooltipOwnerOtherMLT.lua()
 
-    static TriggerVariableButton = 'TriggerFRvar = CreateTrigger() \nBlzTriggerRegisterFrameEvent(TriggerFRvar, FRvar, FRAMEEVENT_CONTROL_CLICK) \nTriggerAddAction(TriggerFRvar, FRlib.FRvrrFunc) \n'
-    static TriggerVariableCheckbox = 'TriggerChFRvar = CreateTrigger() \nBlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_CHECKED) \nBlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_UNCHECKED) \nTriggerAddAction(TriggerChFRvar, function() \nif BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_CHECKED then\nTRIGvar = 2\nelse \nTRIGvar = 1\nend\nend) \n \n'
+  static TriggerVariableButton =
+    'TriggerFRvar = CreateTrigger() \nBlzTriggerRegisterFrameEvent(TriggerFRvar, FRvar, FRAMEEVENT_CONTROL_CLICK) \nTriggerAddAction(TriggerFRvar, FRlib.FRvrrFunc) \n'
+  static TriggerVariableCheckbox =
+    'TriggerChFRvar = CreateTrigger() \nBlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_CHECKED) \nBlzTriggerRegisterFrameEvent(TriggerChFRvar, FRvar, FRAMEEVENT_CHECKBOX_UNCHECKED) \nTriggerAddAction(TriggerChFRvar, function() \nif BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_CHECKED then\nTRIGvar = 2\nelse \nTRIGvar = 1\nend\nend) \n \n'
 
-    static endlibrary = "end\n"
+  static endlibrary = 'end\n'
 
-
-    static HideGameUI = 'BlzHideOriginFrames(true) \nBlzFrameSetSize(BlzGetFrameByName("ConsoleUIBackdrop",0), 0, 0.0001)\n'
-    static HideHeroBar = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_HERO_BAR,0), false)\n';
-    static HideMiniMap = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_MINIMAP,0), false)\n'
-    static HideResources = 'BlzFrameSetVisible(BlzGetFrameByName("ResourceBarFrame",0), false)\n'
-    static HideButtonBar = 'BlzFrameSetVisible(BlzGetFrameByName("UpperButtonBarFrame",0), false)\n'
-    static HidePortrait = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_PORTRAIT, 0), false)\n'
-    static HideChat = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_CHAT_MSG, 0), false)\n'
-    static LoadTOC = 'BlzLoadTOCFile("name.toc")'
-
+  static HideGameUI = 'BlzHideOriginFrames(true) \nBlzFrameSetSize(BlzGetFrameByName("ConsoleUIBackdrop",0), 0, 0.0001)\n'
+  static HideHeroBar = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_HERO_BAR,0), false)\n'
+  static HideMiniMap = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_MINIMAP,0), false)\n'
+  static HideResources = 'BlzFrameSetVisible(BlzGetFrameByName("ResourceBarFrame",0), false)\n'
+  static HideButtonBar = 'BlzFrameSetVisible(BlzGetFrameByName("UpperButtonBarFrame",0), false)\n'
+  static HidePortrait = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_PORTRAIT, 0), false)\n'
+  static HideChat = 'BlzFrameSetVisible(BlzGetOriginFrame(ORIGIN_FRAME_CHAT_MSG, 0), false)\n'
+  static LoadTOC = 'BlzLoadTOCFile("name.toc")'
 }
 
- 
-
-
-
-
 export class Typescript implements I_Templates {
-    static classDeclare =
-      'export class FRlib {\n\n'
-  
-    static globals = '\n'
-  
-    static declares = '   FRvar: Frame\n'
-    // static declaresArray = "   FRvar: Frame[] = []\n"
-    static declaresBUTTON = '   FRvar: Frame\n   BackdropFRvar: Frame \n'
-    // static declaresBUTTONArray = "   FRvar: Frame[] = []\n   BackdropFRvar: Frame[] = [] \n"
-    static declaresHorBarBack = 'FRvar: Frame \nFRvarBack: Frame \n'
-    static declaresHorBarText = 'FRvar: Frame \nFRvarText: Frame \n'
-    static declaresHorBarBack_Text = 'FRvar: Frame \nFRvarBack: Frame \nFRvarText: Frame \n'
-  
-    static endglobals = '\n'
-  
-    static constructorInit = '  constructor() {\n      let t: Trigger;\n\n'
-  
-    static backdrop =
-      '\nthis.FRvar = new Frame("this.FRvar", OWNERvar, 1, 1, "BACKDROP", "") \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setTexture(PATHvar, 0, true) \n'
-  
-    static button =
-      '\nthis.FRvar = new Frame("ScriptDialogButton", OWNERvar, 0, 0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \nthis.BackdropFRvar = new Frame(" this.BackdropFRvar ", this.FRvar, 1, 1, "BACKDROP", "") \nthis.BackdropFRvar.setAllPoints(this.FRvar) \nthis.BackdropFRvar.setTexture(PATHvar, 0, true) \n'
-  
-    static ScriptDialogButton =
-      '\nthis.FRvar = new Frame("ScriptDialogButton", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setText(TEXTvar) \n  .setScale(FRscale) \n '
-    static BrowserButton =
-      '\nthis.FRvar = new Frame("BrowserButton", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setText(TEXTvar) \n  .setScale(FRscale) \n'
-    static CheckListBox =
-      '\nthis.FRvar = new Frame("CheckListBox", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static EscMenuBackdrop =
-      '\nthis.FRvar = new Frame("EscMenuBackdrop", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static OptionsPopupMenuBackdropTemplate =
-      '\nthis.FRvar = new Frame("OptionsPopupMenuBackdropTemplate", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonBaseTemplate =
-      '\nthis.FRvar = new Frame("QuestButtonBaseTemplate", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonDisabledBackdropTemplate =
-      '\nthis.FRvar = new Frame("QuestButtonDisabledBackdropTemplate", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestButtonPushedBackdropTemplate =
-      '\nthis.FRvar = new Frame("QuestButtonPushedBackdropTemplate", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static QuestCheckBox =
-      '\nthis.FRvar = new Frame("QuestCheckBox", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static InvisButton =
-      '\nthis.FRvar = new Frame("FRvar", OWNERvar, 0,0, "GLUEBUTTON", "") \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n'
-    static TextFrame = `\nthis.FRvar = new Frame("FRvar", OWNERvar, 0,0, "TEXT", "") \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setText(TEXTvar) \n  .setEnabled(false) \n  .setScale(FRscale) \nBlzFrameSetTextAlignment(this.FRvar.handle, ALIGN_VER, ALIGN_HOR) \n`
-    static HorizontalBar =
-      '\nthis.FRvar = new Frame("FRvar", OWNERvar, 0,0, "SIMPLESTATUSBAR", "") \n  .setTexture(PATHvar, 0, true) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setValue(100) \n'
-    static HorizontalBarWiBackground =
-      '\nthis.FRvarBack = new Frame("this.FRvarBack", Frame.fromOrigin(ORIGIN_FRAME_GAME_UI, 0), 1, 1, "BACKDROP", "") \n   .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n   .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n   .setTexture(BACKvar, 0, true) \nthis.FRvar = new Frame("this.FRvar", this.FRvarBack, 1, 1, "SIMPLESTATUSBAR", "") \n  .setTexture(PATHvar, 0, true) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setValue(50) \n'
-    static HorizontalBarWiText =
-      '\nthis.FRvar = new Frame("FRvar", Frame.fromOrigin(ORIGIN_FRAME_GAME_UI, 0), 0, 0, "SIMPLESTATUSBAR", "") \n  .setTexture(PATHvar, 0, true) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setValue(100) \nthis.FRvarText = new Frame("name", Frame.fromOrigin( ORIGIN_FRAME_GAME_UI, 0), 0, 0, "TEXT", "") \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setText(TEXTvar) \n  .setEnabled(false) \n  .setScale(FRscale) \nBlzFrameSetTextAlignment(this.FRvarText.handle, ALIGN_VER, ALIGN_HOR) \n'
-    static HorizontalBarWiBackground_Text =
-      '\nthis.FRvarBack = new Frame("this.FRvarBack", Frame.fromOrigin(ORIGIN_FRAME_GAME_UI, 0), 1, 1, "BACKDROP", "") \n   .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n   .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n   .setTexture(BACKvar, 0, true) \nthis.FRvar = new Frame("this.FRvar", this.FRvarBack, 1, 1, "SIMPLESTATUSBAR", "") \n  .setTexture(PATHvar, 0, true) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setValue(50) \nthis.FRvarText = new Frame("name", Frame.fromOrigin( ORIGIN_FRAME_GAME_UI, 0), 0, 0, "TEXT", "") \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setText(TEXTvar) \n  .setEnabled(false) \n  .setScale(FRscale) \nBlzFrameSetTextAlignment(this.FRvarText.handle, ALIGN_VER, ALIGN_HOR) \n'
-    static TextArea = `\nthis.FRvar = new Frame("FRvar", OWNERvar, 0,0, "TEXTAREA", "EscMenuTextAreaTemplate") \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setText(TEXTvar) \n`
-    static EditBox =
-      '\nthis.FRvar = new Frame("EscMenuEditBoxTemplate", OWNERvar,0,0) \n  .setAbsPoint(FRAMEPOINT_TOPLEFT, TOPLEFTXvar, TOPLEFTYvar) \n  .setAbsPoint(FRAMEPOINT_BOTTOMRIGHT, BOTRIGHTXvar, BOTRIGHTYvar) \n  .setText(TEXTvar)\n'
-  
-    static TooltipOwnerButton = `OWNERvar.setTooltip(this.FRvar) \n`
-    static TooltipOwnerOther = `const TooltipFRvar = new Frame("this.FRvar", OWNERvar, 1, 1, "FRAME", "") \nTooltipFRvar.setAllPoints(OWNERvar) \nTooltipFRvar.setTooltip(this.FRvar) \n`
-  
-    static ButtonTriggerSetup =
-      't = new Trigger() \nt.triggerRegisterFrameEvent(this.FRvar, FRAMEEVENT_CONTROL_CLICK) \nt.addAction( () => {\nthis.FRvar.enabled = false \nthis.FRvar.enabled = true \n})\n'
-    static TriggerVariableCheckbox =
-      't = new Trigger() \nt.triggerRegisterFrameEvent(this.FRvar, FRAMEEVENT_CHECKBOX_CHECKED) \nt.triggerRegisterFrameEvent(this.FRvar, FRAMEEVENT_CHECKBOX_UNCHECKED) \nt.addAction( () => {\nif(BlzGetTriggerFrameEvent() == FRAMEEVENT_CHECKBOX_CHECKED) {\n//actions\n} else {\n//actions\n}\n})\n'
-  
-    static endconstructor_library = '}\n\n}\n'
-  }
-  
-  
+  static classDeclare =
+    'export class FRlib {\n  protected static instance: FRlib\n\n  static getInstance() {\n    if (!FRlib.instance) FRlib.instance = new FRlib()\n    return FRlib.instance\n  }\n'
+
+  static globals = '\n'
+
+  static declares = '   FRvar: Frame\n'
+  // static declaresArray = "   FRvar: Frame[] = []\n"
+  static declaresBUTTON = '   FRvar: Frame\n   BackdropFRvar: Frame \n'
+  // static declaresBUTTONArray = "   FRvar: Frame[] = []\n   BackdropFRvar: Frame[] = [] \n"
+  static declaresHorBarBack = 'FRvar: Frame \nFRvarBack: Frame \n'
+  static declaresHorBarText = 'FRvar: Frame \nFRvarText: Frame \n'
+  static declaresHorBarBack_Text = 'FRvar: Frame \nFRvarBack: Frame \nFRvarText: Frame \n'
+
+  static endglobals = '\n'
+
+  static constructorInit = '  private constructor() {\n      let t: Trigger;\n\n'
+
+  static backdrop = BackdropMLT.ts('  ')
+  static button = Button1MLT.ts('  ') + Button2MLT.ts('  ')
+
+  static ScriptDialogButton = ScriptDialogButtonMLT.ts('  ')
+  static BrowserButton = BrowserButtonMLT.ts('  ')
+  static CheckListBox = CheckListBoxMLT.ts('  ')
+  static EscMenuBackdrop = EscMenuBackdropMLT.ts('  ')
+  static OptionsPopupMenuBackdropTemplate = OptionsPopupMenuBackdropTemplateMLT.ts('  ')
+  static QuestButtonBaseTemplate = QuestButtonBaseTemplateMLT.ts('  ')
+  static QuestButtonDisabledBackdropTemplate = QuestButtonDisabledBackdropTemplateMLT.ts('  ')
+  static QuestButtonPushedBackdropTemplate = QuestButtonPushedBackdropTemplateMLT.ts('  ')
+  static QuestCheckBox = QuestCheckBoxMLT.ts('  ')
+  static InvisButton = InvisButtonMLT.ts('  ')
+  static TextFrame = TextFrameMLT.ts('  ')
+  static HorizontalBar = HorizontalBarMLT.ts('  ')
+  static HorizontalBarWiBackground = HorizontalBarWiBackground1MLT.ts('  ') + HorizontalBarWiBackground2MLT.ts('  ')
+  static HorizontalBarWiText = HorizontalBarWiText1MLT.ts('  ') + HorizontalBarWiText2MLT.ts('  ')
+  static HorizontalBarWiBackground_Text =
+    HorizontalBarWiBackground_Text1MLT.ts('  ') + HorizontalBarWiBackground_Text2MLT.ts('  ') + HorizontalBarWiBackground_Text3MLT.ts('  ')
+  static TextArea = TextAreaMLT.ts('  ')
+  static EditBox = EditBoxMLT.ts('  ')
+
+  static TooltipOwnerButton = TooltipOwnerButtonMLT.ts('  ')
+  static TooltipOwnerOther = TooltipOwnerOtherMLT.ts('  ')
+
+  static ButtonTriggerSetup =
+    't = new Trigger() \nt.triggerRegisterFrameEvent(this.FRvar, FRAMEEVENT_CONTROL_CLICK) \nt.addAction( () => {\nthis.FRvar.enabled = false \nthis.FRvar.enabled = true \n})\n'
+  static TriggerVariableCheckbox =
+    't = new Trigger() \nt.triggerRegisterFrameEvent(this.FRvar, FRAMEEVENT_CHECKBOX_CHECKED) \nt.triggerRegisterFrameEvent(this.FRvar, FRAMEEVENT_CHECKBOX_UNCHECKED) \nt.addAction( () => {\nif(BlzGetTriggerFrameEvent() === FRAMEEVENT_CHECKBOX_CHECKED) {\n// Actions\n} else {\n// Actions\n}\n})\n'
+
+  static endconstructor_library = '}\n\n}\n'
+}


### PR DESCRIPTION
A replacement for the Templates.ts file with the new syntax and a new class "FrameMLText" (Multi-Language Text) that does all of the heavy lifting. I did quite a few tests on my own and everything seems to be working properly in all three languages. I went through and rebuilt all of your static objects that build frames using the new methodology. You'll notice everything is actually defined at the top of the doc currently and then referenced in the individual static classes you specified below to get its specific language definitions. It should be MUCH easier to add additional functionality now without having to create it 3 separate times. Only need to create once using logic and methods similar to how things work in typescript and it will create definitions in all three languages automatically. I may go through and make a similar thing for the few stragglers in there that are still manually defined but I'm pretty happy with how this has so far turned out.